### PR TITLE
refactor: Remove the useless wrapper div in radio-button-group compon…

### DIFF
--- a/packages/ui/src/radio/radio-button-group.tsx
+++ b/packages/ui/src/radio/radio-button-group.tsx
@@ -22,31 +22,29 @@ export default function RadioButtonGroup(
   { listData, currentValue, disabled, onChange, className: groupWrapClass, radioBtnClass, radioLabelRender }
     : Props): JSX.Element {
   return (
-    <div className={cs('radio-btn-group-wrap flex items-center', groupWrapClass)}>
-      <RadioGroup
-        onChange={onChange}
-      >
-        {
-          listData?.map(({ label, value }) => (
-            <Radio
-              disabled={disabled}
-              key={value}
-              label={radioLabelRender ? radioLabelRender({ label, value }) : label}
-              value={value}
-              radioClass="hidden"
-              className={cs(
-                'radio-group-btn justify-center border-1 border-gray-300 -ml-1',
-                {
-                  'radio-group-btn-active bg-blue-100': currentValue === value,
-                  'hover:bg-blue-100': !disabled,
-                  'opacity-60': disabled,
-                },
-                radioBtnClass,
-              )}
-              defaultChecked={currentValue === value}
-            />
-          ))}
-      </RadioGroup>
-    </div>
+    <RadioGroup
+      className={cs('radio-btn-group-wrap flex items-center', groupWrapClass)}
+      onChange={onChange}
+    >
+      {listData?.map(({ label, value }) => (
+        <Radio
+          disabled={disabled}
+          key={value}
+          label={radioLabelRender ? radioLabelRender({ label, value }) : label}
+          value={value}
+          radioClass="hidden"
+          className={cs(
+            'radio-group-btn justify-center border-1 border-gray-300 -ml-1',
+            {
+              'radio-group-btn-active bg-blue-100': currentValue === value,
+              'hover:bg-blue-100': !disabled,
+              'opacity-60': disabled,
+            },
+            radioBtnClass,
+          )}
+          defaultChecked={currentValue === value}
+        />
+      ))}
+    </RadioGroup>
   );
 }


### PR DESCRIPTION
移除one-for-all ui组件radio-button-group多余的div标签