### PR TITLE
refactor: Refactor the convertor params type of computed property

### DIFF
--- a/packages/artery-renderer/src/node-render/hooks/__tests__/index.test.tsx
+++ b/packages/artery-renderer/src/node-render/hooks/__tests__/index.test.tsx
@@ -335,12 +335,13 @@ test('useShouldRender_should_return_expected_value_according_computed_state', ()
         },
       ],
       fallback: false,
-      convertor: () => {
-        const loading = dummyCTX.statesHubAPI.getState$('some_api_state').value.loading;
-        const sharedState = dummyCTX.statesHubShared.getState$('visible').value;
-        const nodeState = dummyCTX.statesHubShared.getNodeState$(nodePath).value;
+      convertor: (states) => {
+        const _states = states as Record<string, any>;
+        const sharedState = _states.visible;
+        const nodeState = _states[`${nodePath}`];
+        const loading = _states.some_api_state.loading;
 
-        return loading || sharedState || nodeState;
+        return  sharedState || nodeState || loading;
       },
     },
   };
@@ -408,12 +409,12 @@ test('useShouldRender_should_return_Init_value_according_computed_state', () => 
       type: 'computed_property',
       deps: [],
       fallback: false,
-      convertor: () => {
+      convertor: (states) => {
         const loading = dummyCTX.statesHubAPI.getState$('some_api_state').value.loading;
         const sharedState = dummyCTX.statesHubShared.getState$('visible').value;
         const nodeState = dummyCTX.statesHubShared.getNodeState$(nodePath).value;
 
-        return loading || sharedState || nodeState;
+        return sharedState || nodeState || loading;
       },
     },
   };

--- a/packages/artery-renderer/src/use-instantiate-props/utils.ts
+++ b/packages/artery-renderer/src/use-instantiate-props/utils.ts
@@ -64,7 +64,12 @@ export function getComputedState$({
 
     return ctx.statesHubShared.getState$(depID);
   });
-  const initialDeps = deps$.map((dep$) => dep$.value);
+  const initialDeps = deps$.reduce((acc: Record<string, unknown>, dep$, index) => {
+    const key = deps[index].depID;
+    acc[key] = dep$.value;
+    
+    return acc;
+  }, {});
   const state$ = new BehaviorSubject(
     convertState({
       state: initialDeps,


### PR DESCRIPTION
Refactor the convertor params type from Array to Object in computed property hook